### PR TITLE
test package is moved to dev dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,7 +268,7 @@ packages:
     source: hosted
     version: "1.2.0"
   test:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,5 +6,5 @@ homepage: https://github.com/sidsbrmnn/jwt_decode
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
-dependencies:
+dev_dependencies:
   test: ^1.16.8


### PR DESCRIPTION
jwt_decode 0.3.0 can not be used without an additional dependency_override option in latest flutter (stable 2.0.2 and beta 2.1.0-12.2.pre).

Briefly there is the next error.
```
$ flutter pub get
Because every version of flutter_test from sdk depends on test_api 0.2.19 and test >=1.16.7 depends on test_api 0.3.0, flutter_test from sdk is incompatible with test >=1.16.7.
And because jwt_decode >=0.3.0 depends on test ^1.16.8, flutter_test from sdk is incompatible with jwt_decode >=0.3.0.
So, because webui depends on both jwt_decode ^0.3.0 and flutter_test any from sdk, version solving failed.
```

To solve it as a user - I have to add to my pubspec.yaml:
```
dependency_overrides:
  test: 1.16.5
```

This pull request fixes it on jwt_decode side by moving test to dev dependencies.